### PR TITLE
Optional ints bug

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -5,6 +5,8 @@ const snek = @import("lib.zig").Snek;
 const T = struct {
     name: []const u8,
     location: u32,
+    optional_location: ?u32,
+    opt_int: ?usize,
     exists: bool,
     necessary: ?bool,
     filled_optional: ?[]const u8,
@@ -18,5 +20,5 @@ pub fn main() !void {
     const parsed_cli = try cli.parse();
 
     // Necessary is skipped here to showcase optional values being ignored
-    std.debug.print("Name: {s}\n Location: {d}\n Exists: {any}\n Defualt value: {s}\n Filled Optional: {s}\n", .{ parsed_cli.name, parsed_cli.location, parsed_cli.exists, parsed_cli.default_name, parsed_cli.filled_optional orelse "badvalue" });
+    std.debug.print("Name: {s}\n Location: {d}\n Exists: {any}\n Defualt value: {s}\n Filled Optional: {s}\n Optional int: {d}\n Necessary: {any}", .{ parsed_cli.name, parsed_cli.location, parsed_cli.exists, parsed_cli.default_name, parsed_cli.filled_optional orelse "badvalue", parsed_cli.opt_int orelse 420, parsed_cli.necessary orelse false });
 }

--- a/src/sneaky.zig
+++ b/src/sneaky.zig
@@ -166,10 +166,10 @@ pub fn Snek(comptime CliInterface: type) type {
                             @field(&interface, field.name) = try self.parseBool(serialized_arg.value);
                         },
                         .Int => {
-                            @field(&interface, field.name) = try self.parseNumeric(field.type, serialized_arg.value);
+                            @field(&interface, field.name) = try self.parseNumeric(@Type(field_type), serialized_arg.value);
                         },
                         .Float => {
-                            @field(&interface, field.name) = try self.parseNumeric(field.type, serialized_arg.value);
+                            @field(&interface, field.name) = try self.parseNumeric(@Type(field_type), serialized_arg.value);
                         },
                         .Pointer => {
                             // .Pointer is for strings since the underlying type is []const u8 which is a .Pointer type


### PR DESCRIPTION
Fixing bug in parse causing errors to appear whilst using optional integers. 

Optional integers were being treated as the parent type (optional) and not as the base type of the child (int) which was the root of the error.

![Screenshot from 2025-01-05 11-30-06](https://github.com/user-attachments/assets/91662485-b250-4fa9-a06f-c76462c7b0f9)

`field.type` was being incorrectly passed into the `parseNumeric` function and is not corrected to be the `@Type()` of the child